### PR TITLE
Naprawa buga zamiana wartości 4% na 0.04em

### DIFF
--- a/src/sass/main.css
+++ b/src/sass/main.css
@@ -95,7 +95,7 @@
   font-weight: 400;
   line-height: 1.145;
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-700 {
@@ -104,7 +104,7 @@
   font-weight: 400;
   line-height: 1.145;
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-750 {
@@ -113,7 +113,7 @@
   font-weight: 400;
   line-height: 1.145;
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-800 {
@@ -122,7 +122,7 @@
   font-weight: 400;
   line-height: 1.145;
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-850 {
@@ -131,7 +131,7 @@
   font-weight: 400;
   line-height: 1.145;
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-900 {
@@ -166,7 +166,7 @@
   line-height: 2.55;
 }
 .text-325--city {
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 .text-325--address {
   color: var(--text-gray);
@@ -186,7 +186,7 @@
   color: var(--text-white);
   font-weight: 500;
   line-height: 1.86;
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .text-375 {
@@ -204,7 +204,7 @@
 }
 .text-400--products {
   line-height: 1.52;
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .text-copyright {
@@ -216,18 +216,18 @@
 
 @media (min-width: 48em) {
   .header-900 {
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
   .text-300 {
     line-height: 1.76;
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
   .text-325 {
     line-height: 1.76;
   }
   .text-325--quote {
     line-height: 2.16;
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
   .text-400--products {
     line-height: 1.76;
@@ -245,7 +245,7 @@
     line-height: 1.94;
   }
   .text-325 {
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
   .text-325--quote {
     line-height: 1.86;

--- a/src/sass/utils/_typography.scss
+++ b/src/sass/utils/_typography.scss
@@ -19,31 +19,31 @@
 .header-600 {
   @include text(var(--fs-600), var(--text-white), 400, 1.145);
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-700 {
   @include text(var(--fs-700), var(--text-white), 400, 1.145);
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-750 {
   @include text(var(--fs-750), var(--text-pink), 400, 1.145);
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-800 {
   @include text(var(--fs-800), var(--text-pink), 400, 1.145);
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-850 {
   @include text(var(--fs-850), var(--text-pink), 400, 1.145);
   font-family: var(--ff-header);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .header-900 {
@@ -67,7 +67,7 @@
     line-height: 2.55;
   }
   &--city {
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
   &--address {
     color: var(--text-gray);
@@ -85,7 +85,7 @@
 
 .text-350 {
   @include text(var(--fs-350), var(--text-white), 500, 1.86);
-  letter-spacing: 4%;
+  letter-spacing: 0.04em;
 }
 
 .text-375 {
@@ -96,7 +96,7 @@
   @include text(var(--fs-400), var(--text-white), 700, 1.3);
   &--products {
     line-height: 1.52;
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
 }
 
@@ -107,12 +107,12 @@
 // Responsywność czcionek:
 @media (min-width: $tablet-size) {
   .header-900 {
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
 
   .text-300 {
     line-height: 1.76;
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
 
   .text-325 {
@@ -121,7 +121,7 @@
 
   .text-325--quote {
     line-height: 2.16;
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
 
   .text-400--products {
@@ -144,7 +144,7 @@
   }
 
   .text-325 {
-    letter-spacing: 4%;
+    letter-spacing: 0.04em;
   }
 
   .text-325--quote {


### PR DESCRIPTION
Bugfix - w Figmie `letter-spacing` był pokazany 4% - css nie akceptuje takiej wartości - powinna być wartość dziesiętna: `0.04em;`