### PR TITLE
Changed position of buttons and added span in producs descriptions

### DIFF
--- a/src/partials/products.html
+++ b/src/partials/products.html
@@ -10,7 +10,9 @@
           <h3 class="header-600 products-list__header">ice cream</h3>
           <p class="text-400 text-400--products">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et. dolore magna aliqua facilisis.
+            incididunt ut labore et<span class="products-list__span"
+              >. dolore magna aliqua facilisis.</span
+            >
           </p>
           <button type="button" class="button-arrow button-arrow--products">
             <svg>
@@ -30,7 +32,9 @@
           <h3 class="header-600 products-list__header">ice coffee</h3>
           <p class="text-400 text-400--products">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et. dolore magna aliqua facilisis.
+            incididunt ut labore et<span class="products-list__span"
+              >. dolore magna aliqua facilisis.</span
+            >
           </p>
 
           <button type="button" class="button-arrow button-arrow--products">
@@ -51,7 +55,9 @@
           <h3 class="header-600 products-list__header">milkshakes</h3>
           <p class="text-400 text-400--products">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et. dolore magna aliqua facilisis.
+            incididunt ut labore et<span class="products-list__span"
+              >. dolore magna aliqua facilisis.</span
+            >
           </p>
           <button type="button" class="button-arrow button-arrow--products">
             <svg>

--- a/src/sass/partials/_products.scss
+++ b/src/sass/partials/_products.scss
@@ -113,6 +113,8 @@
   }
 }
 .button-arrow--products {
+  position: absolute;
+  bottom: 2.5rem;
   transition-property: transform;
   transition-duration: 500ms;
   transition-timing-function: linear;
@@ -197,6 +199,9 @@
     &__item-overlay {
       font-size: 0.875rem;
     }
+    &__span {
+      display: none;
+    }
   }
   .products-list__item--bg1::before {
     background-image: url('../images/products/ice-cream-tablet.png');
@@ -270,6 +275,9 @@
     &__item-overlay {
       font-size: 1.15rem;
     }
+  }
+  .button-arrow--products {
+    bottom: 3.125rem;
   }
   .products-list__item--bg1::before {
     background-image: url('../images/products/ice-cream-dekstop.png');

--- a/src/sass/partials/_products.scss
+++ b/src/sass/partials/_products.scss
@@ -54,7 +54,7 @@
     align-items: center;
     gap: 1.88rem;
     text-align: center;
-    padding: 10.06rem 2.44rem 2.56rem 2.56rem;
+    padding: 10.06rem 2.44rem 6.875rem 2.56rem;
     &--bg1 {
       background-color: var(--bg-pink);
       position: relative;
@@ -97,8 +97,7 @@
     letter-spacing: 0.04em;
     padding: 2rem 1rem;
     transition-property: opacity;
-    transition-duration: 500ms;
-    transition-timing-function: linear;
+    @extend .transition;
     &--1 {
       color: #f88ca5;
     }
@@ -116,8 +115,7 @@
   position: absolute;
   bottom: 2.5rem;
   transition-property: transform;
-  transition-duration: 500ms;
-  transition-timing-function: linear;
+  @extend .transition;
   &:hover,
   &:focus {
     transform: rotate(-90deg);
@@ -126,8 +124,7 @@
 .button-arrow--products:hover + .products-list__item-overlay,
 .button-arrow--products:focus + .products-list__item-overlay {
   transition-property: opacity;
-  transition-duration: 500ms;
-  transition-timing-function: linear;
+  @extend .transition;
   opacity: 0.9;
 }
 .products-list__item--bg1::before {
@@ -194,7 +191,7 @@
     gap: 1.25rem;
     &__item {
       flex-basis: calc((100% - 40px) / 3);
-      padding: 9.5rem 0.69rem 2.5rem;
+      padding: 9.5rem 0.69rem 6.875rem;
     }
     &__item-overlay {
       font-size: 0.875rem;
@@ -262,7 +259,7 @@
     gap: 1.875rem;
     &__item {
       flex-basis: calc((100% - 60px) / 3);
-      padding: 10.19rem 2.75rem 3.125rem;
+      padding: 10.19rem 2.75rem 7.5rem;
       min-height: 32.81rem;
       gap: 2rem;
     }


### PR DESCRIPTION
Hej! Czytałam wiadomości na Slacku odnośnie mojej sekcji i widziałam, że ludzie podporządkowują się dokładnie do makiety, dlatego ukryłam ten fragment tekstu, którego nie ma na tablecie i desktopie. Wcześniej to zignorowałam, bo stwierdziłam, że to pewnie bez znaczenia. Dominik pisał też, że chodzi o to, żeby kontenery miały taką samą wysokość niezależnie od ilości tekstu - muszą podporządkowywać się do najdłuższego. Sprawdziłam to i jest poprawnie zrobione, ale przyciski uciekały na górę bezpośrednio pod skrócony tekst. Uważam, że powinny być cały czas na dole, niezależnie od tego, dlatego ustawiłam im pozycję absolute i określone odległości od dolnej granicy <li>. Oceń proszę, czy tak jest lepiej i zmerguj według uznania :)